### PR TITLE
TraceMiddleware: turn all but the app argument into keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ An ASGI middleware that sends traces of HTTP requests to Datadog APM.
 **Parameters**
 
 - **app** - An [ASGI] application.
-- **tracer** - _(optional)_ A [`Tracer`] object. Defaults to the global `ddtracer.tracer` object.
+- **tracer** - _(optional)_ A [`Tracer`] object. Defaults to the global `ddtrace.tracer` object.
 - **service** - _(optional)_ Name of the service as it will appear on Datadog.
 - **distributed_tracing** - _(optional)_ Whether to enable [distributed tracing].
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ To automatically send traces to [Datadog APM](https://docs.datadoghq.com/tracing
 
 ```python
 # app.py
-from ddtrace import tracer
 from ddtrace_asgi.middleware import TraceMiddleware
 
 async def app(scope, receive, send):
@@ -33,7 +32,7 @@ async def app(scope, receive, send):
     await send({"type": "http.response.start", "status": 200, "headers": headers})
     await send({"type": "http.response.body", "body": b"Hello, world!"})
 
-app = TraceMiddleware(app, tracer, service="asgi-hello-world")
+app = TraceMiddleware(app, service="asgi-hello-world")
 ```
 
 Then use `ddtrace-run` when serving your application. For example, if serving with Uvicorn:
@@ -52,12 +51,11 @@ For more information on using `ddtrace`, please see the official [`ddtrace`] rep
 </summary>
 
 ```python
-from ddtrace import tracer
 from ddtrace_asgi.middleware import TraceMiddleware
 from starlette.applications import Starlette
 
 app = Starlette()
-app = TraceMiddleware(app, tracer, service="my-starlette-app")
+app.add_middleware(TraceMiddleware, service="my-starlette-app")
 ```
 
 </details>
@@ -68,7 +66,7 @@ app = TraceMiddleware(app, tracer, service="my-starlette-app")
 
 ```python
 class TracingMiddleware:
-    def __init__(self, app, tracer, service="asgi", distributed_tracing=True):
+    def __init__(self, app, tracer=tracer, service="asgi", distributed_tracing=True):
         ...
 ```
 
@@ -77,7 +75,7 @@ An ASGI middleware that sends traces of HTTP requests to Datadog APM.
 **Parameters**
 
 - **app** - An [ASGI] application.
-- **tracer** - A [`Tracer`] object.
+- **tracer** - _(optional)_ A [`Tracer`] object. Defaults to the global `ddtracer.tracer` object.
 - **service** - _(optional)_ Name of the service as it will appear on Datadog.
 - **distributed_tracing** - _(optional)_ Whether to enable [distributed tracing].
 

--- a/ddtrace_asgi/middleware.py
+++ b/ddtrace_asgi/middleware.py
@@ -1,3 +1,4 @@
+from ddtrace import tracer
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import http as http_tags
 from ddtrace.http import store_request_headers, store_response_headers
@@ -13,7 +14,8 @@ class TraceMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        tracer: Tracer,
+        *,
+        tracer: Tracer = tracer,
         service: str = "asgi",
         distributed_tracing: bool = True,
     ) -> None:

--- a/ddtrace_asgi/middleware.py
+++ b/ddtrace_asgi/middleware.py
@@ -1,10 +1,11 @@
-from ddtrace import tracer
+from typing import Optional
+
+from ddtrace import Tracer, tracer as global_tracer
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import http as http_tags
 from ddtrace.http import store_request_headers, store_response_headers
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.settings import config
-from ddtrace.tracer import Tracer
 from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -15,11 +16,13 @@ class TraceMiddleware:
         self,
         app: ASGIApp,
         *,
-        tracer: Tracer = tracer,
+        tracer: Optional[Tracer] = None,
         service: str = "asgi",
         distributed_tracing: bool = True,
     ) -> None:
         self.app = app
+        if tracer is None:
+            tracer = global_tracer
         self.tracer = tracer
         self.service = service
         self._distributed_tracing = distributed_tracing

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,7 +31,7 @@ def tracer() -> Tracer:
 
 @pytest.fixture
 def client(tracer: Tracer) -> typing.Iterator[httpx.Client]:
-    app = TraceMiddleware(hello_world, tracer, service="test_app")
+    app = TraceMiddleware(hello_world, tracer=tracer, service="test_app")
     with httpx.Client(app=app, base_url="http://testserver") as client:
         yield client
 


### PR DESCRIPTION
In order to support framework APIs like `Starlette.add_middleware(MiddleWare, **config)` this only allows kwargs to configure the `TraceMiddleware` in its constructor.

While at it, I thought we could also use the `ddtrace` global tracer as a pragmatic default. 
Not sure what you think of this?!

Fixes #9 